### PR TITLE
fix device ctl file parameter when sandbox is disabled

### DIFF
--- a/Asspp/Backend/DeviceCTL/DeviceCTL.swift
+++ b/Asspp/Backend/DeviceCTL/DeviceCTL.swift
@@ -48,7 +48,7 @@
                 try? FileManager.default.removeItem(at: temporaryJsonFile)
             }
             let arguments = args + [
-                "-j", "tmp/\(filename).json", // will be prefixed with sandbox path by system
+                "-j", temporaryJsonFile.path(),
                 "-q",
             ]
             guard try run(arguments, process: process) else {


### PR DESCRIPTION
This is weird, even when the sandbox is enabled, the process won't append the sandbox prefix anymore🤥