### PR TITLE
Fix: direct download not working

### DIFF
--- a/Asspp/Backend/Downloader/Downloads.swift
+++ b/Asspp/Backend/Downloader/Downloads.swift
@@ -72,6 +72,7 @@ class Downloads {
         DiggerManager.shared.download(with: request.url)
             .speed { speedBytes in
                 Task { @MainActor in
+                    guard request.state.status == .downloading || request.state.status == .pending else { return }
                     let fmt = ByteCountFormatter()
                     fmt.allowedUnits = .useAll
                     fmt.countStyle = .file
@@ -83,6 +84,7 @@ class Downloads {
             }
             .progress { progress in
                 Task { @MainActor in
+                    guard request.state.status == .downloading || request.state.status == .pending else { return }
                     let now = CFAbsoluteTimeGetCurrent()
                     let fraction = progress.fractionCompleted
                     let last = self.lastProgressUpdates[request.id] ?? 0

--- a/Asspp/Interface/Download/AddDownloadView.swift
+++ b/Asspp/Interface/Download/AddDownloadView.swift
@@ -14,6 +14,7 @@ struct AddDownloadView: View {
     @State private var searchType: EntityType = .iPhone
     @State private var selection: AppStore.UserAccount.ID = .init()
     @State private var hint = ""
+    @State private var hintIsError = false
 
     @FocusState private var searchKeyFocused
 
@@ -68,10 +69,18 @@ struct AddDownloadView: View {
                 AsyncButton {
                     guard let account else { return }
                     searchKeyFocused = false
-                    let software = try await ApplePackage.Lookup.lookup(bundleID: bundleID, countryCode: account.account.store)
-                    let appPackage = AppStore.AppPackage(software: software)
-                    try await dvm.startDownload(for: appPackage, accountID: account.id)
-                    hint = "Download Requested"
+                    do {
+                        guard let countryCode = ApplePackage.Configuration.countryCode(for: account.account.store) else { return }
+                        let software = try await ApplePackage.Lookup.lookup(bundleID: bundleID, countryCode: countryCode)
+                        let appPackage = AppStore.AppPackage(software: software)
+                        try await dvm.startDownload(for: appPackage, accountID: account.id)
+                        hint = String(localized: "Download Requested")
+                        hintIsError = false
+                    } catch {
+                        hint = error.localizedDescription
+                        hintIsError = true
+                        throw error
+                    }
                 } label: {
                     Text("Request Download")
                 }
@@ -83,7 +92,7 @@ struct AddDownloadView: View {
                     Text("The package can be installed later from the Downloads page.")
                 } else {
                     Text(hint)
-                        .foregroundStyle(.red)
+                        .foregroundStyle(hintIsError ? .red : .secondary)
                 }
             }
         }


### PR DESCRIPTION
修复了通过 bundleID 直接下载不能用的问题

原因是 Apple 的下载 API 需要传入两个字符的国家代码 （CN）；搜索-下载目前是这样调用的所以可用，但是直接下载传入的是商店区域 ID，不是国家代码，所以会导致API报错。添加了一层转换逻辑

还顺便修复了暂停按钮需要点两次文本才能正确显示的问题

![IMG_E5EFBB5BCFD1-1](https://github.com/user-attachments/assets/bf03ee18-8dd1-4bed-854c-4f9181acce89)
