### PR TITLE
Fix iOS CI by selecting Xcode 26.2 on macOS 26

### DIFF
--- a/.github/workflows/upstream-signed-ios.yml
+++ b/.github/workflows/upstream-signed-ios.yml
@@ -196,7 +196,7 @@ jobs:
         run: |
           set -euo pipefail
           for XCODE_APP in \
-            /Applications/Xcode_26.0.app \
+            /Applications/Xcode_26.2.app \
             /Applications/Xcode_16.4.app \
             /Applications/Xcode_16.3.app \
             /Applications/Xcode.app


### PR DESCRIPTION
```
Select Xcode 26.2 explicitly in the signed iOS build workflow.

The macOS 26 runner currently exposes `/Applications/Xcode_26.0.app`,
but that selection can fail during `xcodebuild archive` because the iOS 26.0
platform is unavailable.

Pinning to Xcode 26.2 uses an installed iOS SDK and restores the CI build.

