### PR TITLE
Add LookInside debug server

### DIFF
--- a/Asspp.xcodeproj/project.pbxproj
+++ b/Asspp.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		50DCBD782F346E01007100D2 /* Certificates in Resources */ = {isa = PBXBuildFile; fileRef = 50DCBD772F346DFE007100D2 /* Certificates */; };
 		50E28B812C40BA52007891E0 /* ColorfulX in Frameworks */ = {isa = PBXBuildFile; productRef = 50E28B802C40BA52007891E0 /* ColorfulX */; };
 		80CD64ED2C42AA2C0073E206 /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 80CD64EC2C42AA2C0073E206 /* KeychainAccess */; };
+		E20AB0982C78DD66AF202F7C /* LookInsideServer in Frameworks */ = {isa = PBXBuildFile; productRef = A57ACB25387C8C8F3E31EC36 /* LookInsideServer */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -30,7 +31,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		50DCBC2D2F346C6F007100D2 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		50DCBC2D2F346C6F007100D2 /* Exceptions for "Asspp" folder in "Asspp" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
@@ -45,8 +46,29 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		50DCBBB42F346C57007100D2 /* Configuration */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Configuration; sourceTree = "<group>"; };
-		50DCBBF92F346C6F007100D2 /* Asspp */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (50DCBC2D2F346C6F007100D2 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Asspp; sourceTree = "<group>"; };
+		50DCBBB42F346C57007100D2 /* Configuration */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = Configuration;
+			sourceTree = "<group>";
+		};
+		50DCBBF92F346C6F007100D2 /* Asspp */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				50DCBC2D2F346C6F007100D2 /* Exceptions for "Asspp" folder in "Asspp" target */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = Asspp;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -68,6 +90,7 @@
 				80CD64ED2C42AA2C0073E206 /* KeychainAccess in Frameworks */,
 				50D44D1C2C3F92BB00CF6A69 /* NIO in Frameworks */,
 				50D44D202C3F92BB00CF6A69 /* NIOTLS in Frameworks */,
+				E20AB0982C78DD66AF202F7C /* LookInsideServer in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -135,6 +158,7 @@
 				507974622E784D4E0016F540 /* Digger */,
 				50ABFB112F48A6D60077DE1A /* ApplePackage */,
 				50ABFE1E2F48AAE50077DE1A /* ButtonKit */,
+				A57ACB25387C8C8F3E31EC36 /* LookInsideServer */,
 			);
 			productName = Asspp;
 			productReference = 50D44D022C3F91F700CF6A69 /* Asspp.app */;
@@ -177,6 +201,7 @@
 				507974612E784D4E0016F540 /* XCRemoteSwiftPackageReference "Digger" */,
 				50ABFB102F48A6D60077DE1A /* XCRemoteSwiftPackageReference "ApplePackage" */,
 				50ABFE1D2F48AAE50077DE1A /* XCRemoteSwiftPackageReference "ButtonKit" */,
+				82E7AE7277E13A750B401DE9 /* XCRemoteSwiftPackageReference "LookInside-Release" */,
 			);
 			productRefGroup = 50D44D032C3F91F700CF6A69 /* Products */;
 			projectDirPath = "";
@@ -357,6 +382,10 @@
 			baseConfigurationReferenceAnchor = 50DCBBB42F346C57007100D2 /* Configuration */;
 			baseConfigurationReferenceRelativePath = Release.xcconfig;
 			buildSettings = {
+				EXCLUDED_SOURCE_FILE_NAMES = (
+					"$(inherited)",
+					"LookInsideServer*",
+				);
 				INFOPLIST_KEY_CFBundleDisplayName = Asspp;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "Asspp requires this permission to communicate with install service on your device.";
@@ -413,7 +442,7 @@
 			repositoryURL = "https://github.com/Dean151/ButtonKit";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.7.0;
+				minimumVersion = 0.7.1;
 			};
 		};
 		50D0C8B62C40187800538F49 /* XCRemoteSwiftPackageReference "vapor" */ = {
@@ -478,6 +507,14 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 4.2.2;
+			};
+		};
+		82E7AE7277E13A750B401DE9 /* XCRemoteSwiftPackageReference "LookInside-Release" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/LookInsideApp/LookInside-Release.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.2.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -551,6 +588,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 80CD64EB2C42AA2C0073E206 /* XCRemoteSwiftPackageReference "KeychainAccess" */;
 			productName = KeychainAccess;
+		};
+		A57ACB25387C8C8F3E31EC36 /* LookInsideServer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 82E7AE7277E13A750B401DE9 /* XCRemoteSwiftPackageReference "LookInside-Release" */;
+			productName = LookInsideServer;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Asspp.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Asspp.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,366 +1,375 @@
 {
-  "originHash" : "33adb6c1ab0add24d2eee32d717223f24bd55a06fa81930f542f8070784ed96f",
-  "pins" : [
+  "originHash": "86e6fc1bbfdf6ad53749b0c1f573995380840323103579bfac9d87fdc5f195ad",
+  "pins": [
     {
-      "identity" : "anycodable",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Flight-School/AnyCodable",
-      "state" : {
-        "revision" : "862808b2070cd908cb04f9aafe7de83d35f81b05",
-        "version" : "0.6.7"
+      "identity": "anycodable",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/Flight-School/AnyCodable",
+      "state": {
+        "revision": "862808b2070cd908cb04f9aafe7de83d35f81b05",
+        "version": "0.6.7"
       }
     },
     {
-      "identity" : "applepackage",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Lakr233/ApplePackage",
-      "state" : {
-        "revision" : "fd4860b78eb2db60a0dcbe7e5a6e4a3d2cae004e",
-        "version" : "1.2.3"
+      "identity": "applepackage",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/Lakr233/ApplePackage",
+      "state": {
+        "revision": "fd4860b78eb2db60a0dcbe7e5a6e4a3d2cae004e",
+        "version": "1.2.3"
       }
     },
     {
-      "identity" : "async-http-client",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-server/async-http-client.git",
-      "state" : {
-        "revision" : "52ed9d172018e31f2dbb46f0d4f58d66e13c281e",
-        "version" : "1.31.0"
+      "identity": "async-http-client",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/swift-server/async-http-client.git",
+      "state": {
+        "revision": "52ed9d172018e31f2dbb46f0d4f58d66e13c281e",
+        "version": "1.31.0"
       }
     },
     {
-      "identity" : "async-kit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/vapor/async-kit.git",
-      "state" : {
-        "revision" : "6f3615ccf2ac3c2ae0c8087d527546e9544a43dd",
-        "version" : "1.21.0"
+      "identity": "async-kit",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/vapor/async-kit.git",
+      "state": {
+        "revision": "6f3615ccf2ac3c2ae0c8087d527546e9544a43dd",
+        "version": "1.21.0"
       }
     },
     {
-      "identity" : "buttonkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Dean151/ButtonKit",
-      "state" : {
-        "revision" : "a2cd90c52272cf23b2c5f2c701ffd194da539d9b",
-        "version" : "0.7.0"
+      "identity": "buttonkit",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/Dean151/ButtonKit",
+      "state": {
+        "revision": "41e29c1c51ca21b250fbf92931f103e1302fe910",
+        "version": "0.7.1"
       }
     },
     {
-      "identity" : "colorfulx",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Lakr233/ColorfulX",
-      "state" : {
-        "revision" : "2f008fcffc7f23811b2ba70eda77c57223815bc3",
-        "version" : "6.0.2"
+      "identity": "colorfulx",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/Lakr233/ColorfulX",
+      "state": {
+        "revision": "2f008fcffc7f23811b2ba70eda77c57223815bc3",
+        "version": "6.0.2"
       }
     },
     {
-      "identity" : "colorvector",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Lakr233/ColorVector.git",
-      "state" : {
-        "revision" : "6da8726bf38d68eb943d0f2139ac2a1fac70e65b",
-        "version" : "1.0.4"
+      "identity": "colorvector",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/Lakr233/ColorVector.git",
+      "state": {
+        "revision": "6da8726bf38d68eb943d0f2139ac2a1fac70e65b",
+        "version": "1.0.4"
       }
     },
     {
-      "identity" : "console-kit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/vapor/console-kit.git",
-      "state" : {
-        "revision" : "742f624a998cba2a9e653d9b1e91ad3f3a5dff6b",
-        "version" : "4.15.2"
+      "identity": "console-kit",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/vapor/console-kit.git",
+      "state": {
+        "revision": "742f624a998cba2a9e653d9b1e91ad3f3a5dff6b",
+        "version": "4.15.2"
       }
     },
     {
-      "identity" : "digger",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Lakr233/Digger",
-      "state" : {
-        "revision" : "265c84aa4a447564628d2788e63efc3ab7779d7e",
-        "version" : "0.0.5"
+      "identity": "digger",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/Lakr233/Digger",
+      "state": {
+        "revision": "265c84aa4a447564628d2788e63efc3ab7779d7e",
+        "version": "0.0.5"
       }
     },
     {
-      "identity" : "keychainaccess",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/kishikawakatsumi/KeychainAccess.git",
-      "state" : {
-        "revision" : "84e546727d66f1adc5439debad16270d0fdd04e7",
-        "version" : "4.2.2"
+      "identity": "keychainaccess",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/kishikawakatsumi/KeychainAccess.git",
+      "state": {
+        "revision": "84e546727d66f1adc5439debad16270d0fdd04e7",
+        "version": "4.2.2"
       }
     },
     {
-      "identity" : "kingfisher",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/onevcat/Kingfisher",
-      "state" : {
-        "revision" : "2ef543ee21d63734e1c004ad6c870255e8716c50",
-        "version" : "7.12.0"
+      "identity": "kingfisher",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/onevcat/Kingfisher",
+      "state": {
+        "revision": "2ef543ee21d63734e1c004ad6c870255e8716c50",
+        "version": "7.12.0"
       }
     },
     {
-      "identity" : "msdisplaylink",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Lakr233/MSDisplayLink.git",
-      "state" : {
-        "revision" : "ebf5823cb5fc1326639d9a05bc06d16bbe82989f",
-        "version" : "2.0.8"
+      "identity": "lookinside-release",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/LookInsideApp/LookInside-Release.git",
+      "state": {
+        "revision": "7514cfa8bd24a78f74d8b982c429e7d61ef58134",
+        "version": "0.2.2"
       }
     },
     {
-      "identity" : "multipart-kit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/vapor/multipart-kit.git",
-      "state" : {
-        "revision" : "3498e60218e6003894ff95192d756e238c01f44e",
-        "version" : "4.7.1"
+      "identity": "msdisplaylink",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/Lakr233/MSDisplayLink.git",
+      "state": {
+        "revision": "ebf5823cb5fc1326639d9a05bc06d16bbe82989f",
+        "version": "2.0.8"
       }
     },
     {
-      "identity" : "routing-kit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/vapor/routing-kit.git",
-      "state" : {
-        "revision" : "1a10ccea61e4248effd23b6e814999ce7bdf0ee0",
-        "version" : "4.9.3"
+      "identity": "multipart-kit",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/vapor/multipart-kit.git",
+      "state": {
+        "revision": "3498e60218e6003894ff95192d756e238c01f44e",
+        "version": "4.7.1"
       }
     },
     {
-      "identity" : "springinterpolation",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Lakr233/SpringInterpolation.git",
-      "state" : {
-        "revision" : "cdb556516daa9b43c16aae9436dd39e19ff930fd",
-        "version" : "1.4.0"
+      "identity": "routing-kit",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/vapor/routing-kit.git",
+      "state": {
+        "revision": "1a10ccea61e4248effd23b6e814999ce7bdf0ee0",
+        "version": "4.9.3"
       }
     },
     {
-      "identity" : "swift-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-algorithms.git",
-      "state" : {
-        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
-        "version" : "1.2.1"
+      "identity": "springinterpolation",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/Lakr233/SpringInterpolation.git",
+      "state": {
+        "revision": "cdb556516daa9b43c16aae9436dd39e19ff930fd",
+        "version": "1.4.0"
       }
     },
     {
-      "identity" : "swift-asn1",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-asn1.git",
-      "state" : {
-        "revision" : "810496cf121e525d660cd0ea89a758740476b85f",
-        "version" : "1.5.1"
+      "identity": "swift-algorithms",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-algorithms.git",
+      "state": {
+        "revision": "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version": "1.2.1"
       }
     },
     {
-      "identity" : "swift-async-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-async-algorithms.git",
-      "state" : {
-        "revision" : "2971dd5d9f6e0515664b01044826bcea16e59fac",
-        "version" : "1.1.2"
+      "identity": "swift-asn1",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-asn1.git",
+      "state": {
+        "revision": "810496cf121e525d660cd0ea89a758740476b85f",
+        "version": "1.5.1"
       }
     },
     {
-      "identity" : "swift-atomics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-atomics.git",
-      "state" : {
-        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
-        "version" : "1.3.0"
+      "identity": "swift-async-algorithms",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-async-algorithms.git",
+      "state": {
+        "revision": "2971dd5d9f6e0515664b01044826bcea16e59fac",
+        "version": "1.1.2"
       }
     },
     {
-      "identity" : "swift-certificates",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-certificates.git",
-      "state" : {
-        "revision" : "24ccdeeeed4dfaae7955fcac9dbf5489ed4f1a25",
-        "version" : "1.18.0"
+      "identity": "swift-atomics",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-atomics.git",
+      "state": {
+        "revision": "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version": "1.3.0"
       }
     },
     {
-      "identity" : "swift-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections.git",
-      "state" : {
-        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
-        "version" : "1.3.0"
+      "identity": "swift-certificates",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-certificates.git",
+      "state": {
+        "revision": "24ccdeeeed4dfaae7955fcac9dbf5489ed4f1a25",
+        "version": "1.18.0"
       }
     },
     {
-      "identity" : "swift-configuration",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-configuration.git",
-      "state" : {
-        "revision" : "1bb939fe7bbb00b8f8bab664cc90020c035c08d9",
-        "version" : "1.1.0"
+      "identity": "swift-collections",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-collections.git",
+      "state": {
+        "revision": "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
+        "version": "1.3.0"
       }
     },
     {
-      "identity" : "swift-crypto",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-crypto.git",
-      "state" : {
-        "revision" : "6f70fa9eab24c1fd982af18c281c4525d05e3095",
-        "version" : "4.2.0"
+      "identity": "swift-configuration",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-configuration.git",
+      "state": {
+        "revision": "1bb939fe7bbb00b8f8bab664cc90020c035c08d9",
+        "version": "1.1.0"
       }
     },
     {
-      "identity" : "swift-distributed-tracing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-distributed-tracing.git",
-      "state" : {
-        "revision" : "e109d8b5308d0e05201d9a1dd1c475446a946a11",
-        "version" : "1.4.0"
+      "identity": "swift-crypto",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-crypto.git",
+      "state": {
+        "revision": "6f70fa9eab24c1fd982af18c281c4525d05e3095",
+        "version": "4.2.0"
       }
     },
     {
-      "identity" : "swift-http-structured-headers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-http-structured-headers.git",
-      "state" : {
-        "revision" : "76d7627bd88b47bf5a0f8497dd244885960dde0b",
-        "version" : "1.6.0"
+      "identity": "swift-distributed-tracing",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-distributed-tracing.git",
+      "state": {
+        "revision": "e109d8b5308d0e05201d9a1dd1c475446a946a11",
+        "version": "1.4.0"
       }
     },
     {
-      "identity" : "swift-http-types",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-http-types.git",
-      "state" : {
-        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
-        "version" : "1.5.1"
+      "identity": "swift-http-structured-headers",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-http-structured-headers.git",
+      "state": {
+        "revision": "76d7627bd88b47bf5a0f8497dd244885960dde0b",
+        "version": "1.6.0"
       }
     },
     {
-      "identity" : "swift-log",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-log",
-      "state" : {
-        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
-        "version" : "1.10.1"
+      "identity": "swift-http-types",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-http-types.git",
+      "state": {
+        "revision": "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
+        "version": "1.5.1"
       }
     },
     {
-      "identity" : "swift-metrics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-metrics.git",
-      "state" : {
-        "revision" : "f17c111cec972c2a4922cef38cf64f76f7e87886",
-        "version" : "2.8.0"
+      "identity": "swift-log",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-log",
+      "state": {
+        "revision": "bbd81b6725ae874c69e9b8c8804d462356b55523",
+        "version": "1.10.1"
       }
     },
     {
-      "identity" : "swift-nio",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio.git",
-      "state" : {
-        "revision" : "e932d3c4d8f77433c8f7093b5ebcbf91463948a0",
-        "version" : "2.95.0"
+      "identity": "swift-metrics",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-metrics.git",
+      "state": {
+        "revision": "f17c111cec972c2a4922cef38cf64f76f7e87886",
+        "version": "2.8.0"
       }
     },
     {
-      "identity" : "swift-nio-extras",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-extras.git",
-      "state" : {
-        "revision" : "3df009d563dc9f21a5c85b33d8c2e34d2e4f8c3b",
-        "version" : "1.32.1"
+      "identity": "swift-nio",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-nio.git",
+      "state": {
+        "revision": "e932d3c4d8f77433c8f7093b5ebcbf91463948a0",
+        "version": "2.95.0"
       }
     },
     {
-      "identity" : "swift-nio-http2",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-http2.git",
-      "state" : {
-        "revision" : "b6571f3db40799df5a7fc0e92c399aa71c883edd",
-        "version" : "1.40.0"
+      "identity": "swift-nio-extras",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-nio-extras.git",
+      "state": {
+        "revision": "3df009d563dc9f21a5c85b33d8c2e34d2e4f8c3b",
+        "version": "1.32.1"
       }
     },
     {
-      "identity" : "swift-nio-ssl",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-ssl.git",
-      "state" : {
-        "revision" : "173cc69a058623525a58ae6710e2f5727c663793",
-        "version" : "2.36.0"
+      "identity": "swift-nio-http2",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-nio-http2.git",
+      "state": {
+        "revision": "b6571f3db40799df5a7fc0e92c399aa71c883edd",
+        "version": "1.40.0"
       }
     },
     {
-      "identity" : "swift-nio-transport-services",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-transport-services.git",
-      "state" : {
-        "revision" : "60c3e187154421171721c1a38e800b390680fb5d",
-        "version" : "1.26.0"
+      "identity": "swift-nio-ssl",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-nio-ssl.git",
+      "state": {
+        "revision": "173cc69a058623525a58ae6710e2f5727c663793",
+        "version": "2.36.0"
       }
     },
     {
-      "identity" : "swift-numerics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics.git",
-      "state" : {
-        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
-        "version" : "1.1.1"
+      "identity": "swift-nio-transport-services",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-nio-transport-services.git",
+      "state": {
+        "revision": "60c3e187154421171721c1a38e800b390680fb5d",
+        "version": "1.26.0"
       }
     },
     {
-      "identity" : "swift-service-context",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-service-context.git",
-      "state" : {
-        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
-        "version" : "1.3.0"
+      "identity": "swift-numerics",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-numerics.git",
+      "state": {
+        "revision": "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version": "1.1.1"
       }
     },
     {
-      "identity" : "swift-service-lifecycle",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
-      "state" : {
-        "revision" : "9db4c30383d051ece05f77b4a9f7962018dab81f",
-        "version" : "2.10.0"
+      "identity": "swift-service-context",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-service-context.git",
+      "state": {
+        "revision": "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version": "1.3.0"
       }
     },
     {
-      "identity" : "swift-system",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-system.git",
-      "state" : {
-        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
-        "version" : "1.6.4"
+      "identity": "swift-service-lifecycle",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state": {
+        "revision": "9db4c30383d051ece05f77b4a9f7962018dab81f",
+        "version": "2.10.0"
       }
     },
     {
-      "identity" : "vapor",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/vapor/vapor",
-      "state" : {
-        "revision" : "6d06e13021c299aa3300986f4eb5bb143d17ac9b",
-        "version" : "4.121.2"
+      "identity": "swift-system",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/apple/swift-system.git",
+      "state": {
+        "revision": "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version": "1.6.4"
       }
     },
     {
-      "identity" : "websocket-kit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/vapor/websocket-kit.git",
-      "state" : {
-        "revision" : "8666c92dbbb3c8eefc8008c9c8dcf50bfd302167",
-        "version" : "2.16.1"
+      "identity": "vapor",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/vapor/vapor",
+      "state": {
+        "revision": "6d06e13021c299aa3300986f4eb5bb143d17ac9b",
+        "version": "4.121.2"
       }
     },
     {
-      "identity" : "zipfoundation",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/weichsel/ZIPFoundation.git",
-      "state" : {
-        "revision" : "22787ffb59de99e5dc1fbfe80b19c97a904ad48d",
-        "version" : "0.9.20"
+      "identity": "websocket-kit",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/vapor/websocket-kit.git",
+      "state": {
+        "revision": "8666c92dbbb3c8eefc8008c9c8dcf50bfd302167",
+        "version": "2.16.1"
+      }
+    },
+    {
+      "identity": "zipfoundation",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/weichsel/ZIPFoundation.git",
+      "state": {
+        "revision": "22787ffb59de99e5dc1fbfe80b19c97a904ad48d",
+        "version": "0.9.20"
       }
     }
   ],
-  "version" : 3
+  "version": 3
 }

--- a/README.md
+++ b/README.md
@@ -82,3 +82,7 @@ MIT License. See [LICENSE](./LICENSE) for details.
 ---
 
 Copyright © 2025 Lakr Aream. All Rights Reserved.
+
+## Sponsor
+
+[LookInside](https://lookinside-app.com/) helps you inspect a running iOS or macOS app UI from your Mac.

--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ _`ipatool-ios` and `localhost.direct` are no longer used in the project._
 
 MIT License. See [LICENSE](./LICENSE) for details.
 
----
-
-Copyright © 2025 Lakr Aream. All Rights Reserved.
-
 ## Sponsor
 
 [LookInside](https://lookinside-app.com/) helps you inspect a running iOS or macOS app UI from your Mac.
+
+---
+
+Copyright © 2025 Lakr Aream. All Rights Reserved.


### PR DESCRIPTION
## What changed

- Add the LookInside-Release Swift package and link the LookInsideServer product into the app target.
- Exclude LookInsideServer from Release builds with `EXCLUDED_SOURCE_FILE_NAMES = $(inherited) LookInsideServer*`.
- Add the LookInside sponsor block to the root README.

## Validation

- Debug build passes.
- Release build passes.
- Debug artifact contains LookInsideServer.
- Release artifact excludes LookInsideServer.
